### PR TITLE
WIP: Using new Documentation API, fix the deprecation.

### DIFF
--- a/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/GroupDocumentationTarget.java
+++ b/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/GroupDocumentationTarget.java
@@ -1,0 +1,66 @@
+package dev.flikas.spring.boot.assistant.idea.plugin.documentation;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.model.Pointer;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.OrderEntry;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.platform.backend.documentation.DocumentationResult;
+import com.intellij.platform.backend.documentation.DocumentationTarget;
+import com.intellij.platform.backend.presentation.TargetPresentation;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import dev.flikas.spring.boot.assistant.idea.plugin.documentation.service.DocumentationService;
+import dev.flikas.spring.boot.assistant.idea.plugin.metadata.index.MetadataGroup;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.stream.Collectors;
+
+@SuppressWarnings("UnstableApiUsage")
+public class GroupDocumentationTarget implements ProjectDocumentationTarget {
+  private final MetadataGroup group;
+  private final @NotNull Project project;
+
+
+  public GroupDocumentationTarget(MetadataGroup group) {
+    this.group = group;
+    this.project = group.getIndex().project();
+  }
+
+
+  @Override
+  public @NotNull Project getProject() {
+    return this.project;
+  }
+
+
+  @Override
+  public @NotNull TargetPresentation computePresentation() {
+    String locationText = group
+        .getSourceType()
+        .map(PsiElement::getContainingFile)
+        .map(PsiFile::getVirtualFile)
+        .map(f -> ProjectFileIndex.getInstance(project).getOrderEntriesForFile(f))
+        .map(l -> l.stream().map(OrderEntry::getPresentableName).distinct().collect(Collectors.joining(", ")))
+        .orElse(null);
+    OrderEntry a;
+    return TargetPresentation.builder(group.getNameStr())
+        .icon(group.getIcon().getSecond())
+        .containerText(group.getMetadata().getSourceType())
+        .locationText(locationText, AllIcons.Nodes.Library)
+        .presentation();
+  }
+
+
+  @Override
+  public @NotNull Pointer<? extends DocumentationTarget> createPointer() {
+    return Pointer.delegatingPointer(Pointer.hardPointer(group), GroupDocumentationTarget::new);
+  }
+
+
+  @Override
+  public @Nullable DocumentationResult computeDocumentation() {
+    return DocumentationResult.documentation(DocumentationService.getInstance(project).generateDoc(this.group));
+  }
+}

--- a/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/HintDocumentationTarget.java
+++ b/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/HintDocumentationTarget.java
@@ -1,0 +1,50 @@
+package dev.flikas.spring.boot.assistant.idea.plugin.documentation;
+
+import com.intellij.model.Pointer;
+import com.intellij.openapi.project.Project;
+import com.intellij.platform.backend.documentation.DocumentationResult;
+import com.intellij.platform.backend.presentation.TargetPresentation;
+import dev.flikas.spring.boot.assistant.idea.plugin.documentation.service.DocumentationService;
+import dev.flikas.spring.boot.assistant.idea.plugin.metadata.index.hint.Hint;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class HintDocumentationTarget implements ProjectDocumentationTarget {
+  @NotNull private final Hint hintValue;
+  @NotNull private final Project project;
+
+
+  public HintDocumentationTarget(@NotNull Hint hintValue, @NotNull Project project) {
+    this.hintValue = hintValue;
+    this.project = project;
+  }
+
+
+  @Override
+  @NotNull
+  public Project getProject() {
+    return this.project;
+  }
+
+
+  @SuppressWarnings("UnstableApiUsage")
+  @Override
+  public @NotNull Pointer<HintDocumentationTarget> createPointer() {
+    return Pointer.hardPointer(this);
+  }
+
+
+  @SuppressWarnings("UnstableApiUsage")
+  @Override
+  public @NotNull TargetPresentation computePresentation() {
+    return TargetPresentation.builder(hintValue.value())
+        .icon(hintValue.icon())
+        .presentation();
+  }
+
+
+  @Override
+  public @Nullable DocumentationResult computeDocumentation() {
+    return DocumentationResult.documentation(DocumentationService.getInstance(project).generateDoc(hintValue));
+  }
+}

--- a/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/ProjectDocumentationLinkHandler.java
+++ b/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/ProjectDocumentationLinkHandler.java
@@ -1,0 +1,31 @@
+package dev.flikas.spring.boot.assistant.idea.plugin.documentation;
+
+import com.intellij.codeInsight.documentation.DocumentationManager;
+import com.intellij.lang.documentation.psi.UtilKt;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
+import com.intellij.platform.backend.documentation.DocumentationLinkHandler;
+import com.intellij.platform.backend.documentation.DocumentationTarget;
+import com.intellij.platform.backend.documentation.LinkResolveResult;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Workaround for hyperlinks in {@link DocumentationTarget} is not working.
+ */
+@SuppressWarnings({"removal", "UnstableApiUsage"})
+public class ProjectDocumentationLinkHandler implements DocumentationLinkHandler {
+  @Override
+  public @Nullable LinkResolveResult resolveLink(@NotNull DocumentationTarget target, @NotNull String url) {
+    if (target instanceof ProjectDocumentationTarget pdt) {
+      Project project = pdt.getProject();
+      @Nullable Pair<@NotNull PsiElement, @Nullable String> resolved =
+          DocumentationManager.targetAndRef(project, url, null);
+      if (resolved == null) return null;
+      return LinkResolveResult.resolvedTarget(UtilKt.psiDocumentationTargets(resolved.getFirst(), null).getFirst());
+    } else {
+      return null;
+    }
+  }
+}

--- a/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/ProjectDocumentationTarget.java
+++ b/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/ProjectDocumentationTarget.java
@@ -1,0 +1,8 @@
+package dev.flikas.spring.boot.assistant.idea.plugin.documentation;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.platform.backend.documentation.DocumentationTarget;
+
+public interface ProjectDocumentationTarget extends DocumentationTarget {
+  Project getProject();
+}

--- a/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/PropertyDocumentationTarget.java
+++ b/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/PropertyDocumentationTarget.java
@@ -1,0 +1,63 @@
+package dev.flikas.spring.boot.assistant.idea.plugin.documentation;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.model.Pointer;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.OrderEntry;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.platform.backend.documentation.DocumentationResult;
+import com.intellij.platform.backend.documentation.DocumentationTarget;
+import com.intellij.platform.backend.presentation.TargetPresentation;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import dev.flikas.spring.boot.assistant.idea.plugin.documentation.service.DocumentationService;
+import dev.flikas.spring.boot.assistant.idea.plugin.metadata.index.MetadataProperty;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.stream.Collectors;
+
+@SuppressWarnings("UnstableApiUsage")
+public class PropertyDocumentationTarget implements ProjectDocumentationTarget {
+  private final MetadataProperty property;
+  private final Project project;
+
+
+  public PropertyDocumentationTarget(MetadataProperty property) {
+    this.property = property;
+    this.project = property.getIndex().project();
+  }
+
+
+  @Override
+  public Project getProject() {
+    return this.project;
+  }
+
+
+  @Override
+  public @NotNull Pointer<? extends DocumentationTarget> createPointer() {
+    return Pointer.delegatingPointer(Pointer.hardPointer(property), PropertyDocumentationTarget::new);
+  }
+
+
+  @Override
+  public @NotNull TargetPresentation computePresentation() {
+    String locationText = property.getSourceType().map(PsiElement::getContainingFile).map(PsiFile::getVirtualFile)
+        .map(f -> ProjectFileIndex.getInstance(project).getOrderEntriesForFile(f))
+        .map(l -> l.stream().map(OrderEntry::getPresentableName).distinct().collect(Collectors.joining(", ")))
+        .orElse(null);
+
+    return TargetPresentation.builder(property.getNameStr())
+        .icon(property.getIcon().getSecond())
+        .containerText(property.getMetadata().getSourceType())
+        .locationText(locationText, AllIcons.Nodes.Library)
+        .presentation();
+  }
+
+
+  @Override
+  public @Nullable DocumentationResult computeDocumentation() {
+    return DocumentationResult.documentation(DocumentationService.getInstance(project).generateDoc(this.property));
+  }
+}

--- a/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/YamlDocumentationTargetProvider.java
+++ b/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/documentation/YamlDocumentationTargetProvider.java
@@ -1,16 +1,17 @@
 package dev.flikas.spring.boot.assistant.idea.plugin.documentation;
 
-import com.intellij.lang.documentation.AbstractDocumentationProvider;
 import com.intellij.openapi.module.Module;
+import com.intellij.platform.backend.documentation.DocumentationTarget;
+import com.intellij.platform.backend.documentation.PsiDocumentationTargetProvider;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
 import dev.flikas.spring.boot.assistant.idea.plugin.completion.SourceContainer;
-import dev.flikas.spring.boot.assistant.idea.plugin.documentation.service.DocumentationService;
 import dev.flikas.spring.boot.assistant.idea.plugin.filetype.SpringBootConfigurationYamlFileType;
+import dev.flikas.spring.boot.assistant.idea.plugin.metadata.index.MetadataGroup;
 import dev.flikas.spring.boot.assistant.idea.plugin.metadata.index.MetadataItem;
+import dev.flikas.spring.boot.assistant.idea.plugin.metadata.index.MetadataProperty;
 import dev.flikas.spring.boot.assistant.idea.plugin.metadata.service.ModuleMetadataService;
 import dev.flikas.spring.boot.assistant.idea.plugin.misc.PsiElementUtils;
-import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.yaml.YAMLUtil;
@@ -18,13 +19,13 @@ import org.jetbrains.yaml.psi.YAMLKeyValue;
 
 import static com.intellij.openapi.module.ModuleUtilCore.findModuleForPsiElement;
 
-public class YamlDocumentationProvider extends AbstractDocumentationProvider {
-  @Nullable
-  @Nls
+public class YamlDocumentationTargetProvider implements PsiDocumentationTargetProvider {
   @Override
-  public String generateDoc(PsiElement element, @Nullable PsiElement originalElement) {
+  public @Nullable DocumentationTarget documentationTarget(
+      @NotNull PsiElement element, @Nullable PsiElement originalElement
+  ) {
     if (element instanceof SourceContainer ce) {
-      return generateDocumentHtml(ce);
+      return getDocumentationTarget(ce);
     }
 
     if (originalElement != null) element = originalElement;
@@ -45,14 +46,25 @@ public class YamlDocumentationProvider extends AbstractDocumentationProvider {
     @Nullable MetadataItem propertyOrGroup = service.getIndex().getPropertyOrGroup(propertyName);
     if (propertyOrGroup == null) return null;
 
-    return DocumentationService.getInstance(module.getProject()).generateDoc(propertyOrGroup);
+    return getDocumentationTarget(propertyOrGroup);
   }
 
 
   @NotNull
-  private String generateDocumentHtml(SourceContainer sc) {
-    DocumentationService docSvc = DocumentationService.getInstance(sc.getProject());
-    return sc.getSourceMetadataItem().map(docSvc::generateDoc).orElseGet(() ->
-        sc.getSourceHint().map(docSvc::generateDoc).orElseThrow());
+  private DocumentationTarget getDocumentationTarget(SourceContainer sc) {
+    return sc.getSourceMetadataItem().map(this::getDocumentationTarget).orElseGet(() ->
+        sc.getSourceHint().map(h -> new HintDocumentationTarget(h, sc.getProject()))
+            .orElseThrow());
+  }
+
+
+  @NotNull
+  private DocumentationTarget getDocumentationTarget(MetadataItem propertyOrGroup) {
+    if (propertyOrGroup instanceof MetadataProperty property) {
+      return new PropertyDocumentationTarget(property);
+    } else if (propertyOrGroup instanceof MetadataGroup group) {
+      return new GroupDocumentationTarget(group);
+    }
+    throw new IllegalStateException("Unsupported type: " + propertyOrGroup.getClass());
   }
 }

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -105,8 +105,10 @@
     <referencesSearch
         implementation="dev.flikas.spring.boot.assistant.idea.plugin.navigation.PsiToYamlKeySearcher"/>
 
-    <documentationProvider
-        implementation="dev.flikas.spring.boot.assistant.idea.plugin.documentation.YamlDocumentationProvider"/>
+    <platform.backend.documentation.psiTargetProvider
+        implementation="dev.flikas.spring.boot.assistant.idea.plugin.documentation.YamlDocumentationTargetProvider"/>
+    <platform.backend.documentation.linkHandler
+        implementation="dev.flikas.spring.boot.assistant.idea.plugin.documentation.ProjectDocumentationLinkHandler"/>
 
     <moduleService
         serviceInterface="dev.flikas.spring.boot.assistant.idea.plugin.metadata.service.ModuleMetadataService"


### PR DESCRIPTION
But there is using of Internal APIs, because the `psi_element://` link cannot be resolved in the new API, we need a workaround.