### PR TITLE
fix：Fixed the StackOverflowError caused by the self-referencing property class

### DIFF
--- a/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/metadata/index/AggregatedMetadataIndex.java
+++ b/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/metadata/index/AggregatedMetadataIndex.java
@@ -1,7 +1,6 @@
 package dev.flikas.spring.boot.assistant.idea.plugin.metadata.index;
 
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiClass;
 import dev.flikas.spring.boot.assistant.idea.plugin.metadata.source.PropertyName;
 import dev.flikas.spring.boot.assistant.idea.plugin.misc.MutableReference;
 import org.jetbrains.annotations.NotNull;
@@ -12,15 +11,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class AggregatedMetadataIndex implements MetadataIndex {
   private final Deque<MutableReference<? extends MetadataIndex>> indexes = new ConcurrentLinkedDeque<>();
-  private final Set<PsiClass> visitedClasses = new CopyOnWriteArraySet<>();
 
 
   public AggregatedMetadataIndex() {
@@ -64,14 +60,6 @@ public class AggregatedMetadataIndex implements MetadataIndex {
       ref.refresh();
       if (ref.dereference() == null) iterator.remove();
     }
-  }
-
-  public void addVisitedClass(PsiClass valueClass) {
-    visitedClasses.add(valueClass);
-  }
-
-  public boolean isVisitedClass(PsiClass valueClass) {
-    return visitedClasses.contains(valueClass);
   }
 
   @Override

--- a/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/metadata/index/AggregatedMetadataIndex.java
+++ b/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/metadata/index/AggregatedMetadataIndex.java
@@ -1,6 +1,7 @@
 package dev.flikas.spring.boot.assistant.idea.plugin.metadata.index;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiClass;
 import dev.flikas.spring.boot.assistant.idea.plugin.metadata.source.PropertyName;
 import dev.flikas.spring.boot.assistant.idea.plugin.misc.MutableReference;
 import org.jetbrains.annotations.NotNull;
@@ -11,12 +12,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class AggregatedMetadataIndex implements MetadataIndex {
   private final Deque<MutableReference<? extends MetadataIndex>> indexes = new ConcurrentLinkedDeque<>();
+  private final Set<PsiClass> visitedClasses = new CopyOnWriteArraySet<>();
 
 
   public AggregatedMetadataIndex() {
@@ -62,6 +66,13 @@ public class AggregatedMetadataIndex implements MetadataIndex {
     }
   }
 
+  public void addVisitedClass(PsiClass valueClass) {
+    visitedClasses.add(valueClass);
+  }
+
+  public boolean isVisitedClass(PsiClass valueClass) {
+    return visitedClasses.contains(valueClass);
+  }
 
   @Override
   public boolean isEmpty() {

--- a/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/metadata/service/ProjectClassMetadataService.java
+++ b/plugin/src/main/java/dev/flikas/spring/boot/assistant/idea/plugin/metadata/service/ProjectClassMetadataService.java
@@ -102,6 +102,8 @@ final class ProjectClassMetadataService implements Disposable {
     } else {
       PsiClass valueClass = PsiTypeUtils.resolveClassInType(type);
       if (valueClass == null) return index;
+      if (index.isVisitedClass(valueClass)) return index;
+      index.addVisitedClass(valueClass);
       ConfigurationMetadata metadata = new ConfigurationMetadata();
       String[] writableProperties = PropertyUtil.getWritableProperties(valueClass, true);
       for (String fieldName : writableProperties) {


### PR DESCRIPTION
fix：Fixed the StackOverflowError caused by the self-referencing property class. [Related issue](https://github.com/flikas/idea-spring-boot-assistant/issues/4)  .
caused by io.swagger.v3.oas.models.media.Schema of  SpringDocConfigProperties.
https://github.com/springdoc/springdoc-openapi/blob/main/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SpringDocConfigProperties.java